### PR TITLE
Update the version to Trixie

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -19,7 +19,7 @@ on:
 jobs:
   build:
     name: Build docker image
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Install dependencies
         run: sudo apt-get update && sudo apt-get install fuse2fs fdisk jq

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -4,10 +4,13 @@ on:
     inputs:
       raspios-release-name:
         description:  Raspios release name
-        default: bookworm
+        default: trixie
       raspios-release-date:
         description:  Raspios release date
-        default: 2024-03-15
+        default: 2025-10-02
+      raspios-file-date:
+        description:  Raspios file date
+        default: 2025-10-01
       latest:
         description: Tag as latest
         type: boolean
@@ -25,6 +28,7 @@ jobs:
         run: mkdir out
       - name: Mount image
         env:
+          FILE_DATE: ${{ github.event.inputs.raspios-file-date }}
           DATE: ${{ github.event.inputs.raspios-release-date }}
           DEBIAN: ${{ github.event.inputs.raspios-release-name }}
         run: ./mount-image.sh out

--- a/mount-image.sh
+++ b/mount-image.sh
@@ -2,10 +2,11 @@
 
 set -e
 
-DATE="${DATE:-2024-03-15}"
-DEBIAN="${DEBIAN:-bookworm}"
+DATE="${DATE:-2025-10-02}"
+FILE_DATE="${FILE_DATE:-2025-10-01}"
+DEBIAN="${DEBIAN:-trixie}"
 
-IMAGE="${DATE}-raspios-${DEBIAN}-arm64-lite.img"
+IMAGE="${FILE_DATE}-raspios-${DEBIAN}-arm64-lite.img"
 
 if [ $# -lt 1 ]; then
     echo "Usage: $0 <directory>"


### PR DESCRIPTION
- Change default release name from bookworm to trixie
- Update default DATE to 2025-10-01 script
- Update default release date to 2025-10-02 in workflow
  - Because file upload date differs from release date for the latest release.
- Update build job to use ubuntu-24.04 runner
  - Because the following error occurs when using ubuntu 22.04

```
Mounting 2025-10-01-raspios-trixie-arm64-lite.img2
e2fsck 1.46.5 (30-Dec-2021)
2025-10-01-raspios-trixie-arm64-lite.img2 has unsupported feature(s): FEATURE_C12
e2fsck: Get a newer version of e2fsck!
```  